### PR TITLE
Removed upcase for DB Table name for better support with MySQL

### DIFF
--- a/lib/db_sync.rb
+++ b/lib/db_sync.rb
@@ -26,7 +26,7 @@ module DbSync
       i = "000"    
       sql  = "SELECT * FROM %s"    
       File.open("#{location.first}/#{table_name}.yml", 'w') do |file|      
-        data = ActiveRecord::Base.connection.select_all(sql % table_name.upcase)      
+        data = ActiveRecord::Base.connection.select_all(sql % table_name)      
         file.write data.inject({}) { |hash, record|  
           hash["#{table_name}_#{i.succ!}"] = record        
           hash      

--- a/lib/db_sync.rb
+++ b/lib/db_sync.rb
@@ -1,6 +1,6 @@
 require "db_sync/version"
 require 'db_sync/railtie' if defined?(Rails)
-YAML::ENGINE.yamler = "psych"
+# YAML::ENGINE.yamler = "psych"
 module DbSync
 
   class Configuration
@@ -21,29 +21,29 @@ module DbSync
   end
 
   def self.dump_data
-    DbSync.configuration.sync_tables.each do |table_name|    
-      location = FileUtils.mkdir_p "#{Rails.root}/db/data"    
-      i = "000"    
-      sql  = "SELECT * FROM %s"    
-      File.open("#{location.first}/#{table_name}.yml", 'w') do |file|      
-        data = ActiveRecord::Base.connection.select_all(sql % table_name)      
-        file.write data.inject({}) { |hash, record|  
-          hash["#{table_name}_#{i.succ!}"] = record        
-          hash      
-        }.to_yaml      
-        puts "wrote #{file.path} /"    
-      end  
+    DbSync.configuration.sync_tables.each do |table_name|
+      location = FileUtils.mkdir_p "#{Rails.root}/db/data"
+      i = "000"
+      sql  = "SELECT * FROM %s"
+      File.open("#{location.first}/#{table_name}.yml", 'w') do |file|
+        data = ActiveRecord::Base.connection.select_all(sql % table_name)
+        file.write data.inject({}) { |hash, record|
+          hash["#{table_name}_#{i.succ!}"] = record
+          hash
+        }.to_yaml
+        puts "wrote #{file.path} /"
+      end
     end
   end
 
   def self.load_data
-    Dir["#{Rails.root}/db/data/*{yml}"].each do |data_file|    
-      load_document(data_file)  
+    Dir["#{Rails.root}/db/data/*{yml}"].each do |data_file|
+      load_document(data_file)
     end
   end
 
   def self.load_document(filename)
-    YAML.load_documents(File.new(Rails.root.join(filename), "r").read).each do |row| 
+    YAML.load_documents(File.new(Rails.root.join(filename), "r").read).each do |row|
       columns =  row.values.first.collect { |v| v[0]}
       values = row.values.first.collect { |v| ActiveRecord::Base.connection.quote(v[1])}
       table_name = File.basename(filename).split(".").first


### PR DESCRIPTION
Tested with Ruby 2.5.1p57

Removed the psych definition for yamler. It wasn't needed and caused issues with Ruby 2.5.x, possible older ruby versions as well. 

Removed the upcase when doing the sql select call as this was causing issues with MySQL.