### PR TITLE
Add Load Order and Fix Psych load files

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ WARNING: this overwrites the contents of this existing table.
 Or run this to load the tables back in the order specified in the sync_tables array.
 WARNING: this overwrites the contents of this existing table.  
 
-    bundle exec rake db_sync:load_data
+    bundle exec rake db_sync:load_data_order
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Have you ever gone to test a specific or develop a feature, except it requires use of data that currently only exists in production?   
 
-Instead of going through a very time-consuming database dump and load process, you can use this gem instead. 
+Instead of going through a very time-consuming database dump and load process, you can use this gem instead.
 
 It works by dumping certain tables you want into some yaml files in db/data.  You can then easily load them into your database.  
 
@@ -19,21 +19,29 @@ And in config/initializers/db_sync.rb
 
     DbSync.configure do |config|
       config.sync_tables = ["TABLE_NAME"]
+
+      #DEFAULT is db/data/
+      config.db_data_folder = "overide/the/folder/path/to/load/the/data" #OPTIONAL
     end
 
-## Usage 
+## Usage
 
 Run this to dump the tables you specified in the initializer to db/data
-   
-    bundle exec rake db_sync:dump_data 
-    
+
+    bundle exec rake db_sync:dump_data
+
 Or run against a specific rails environment
 
     bundle exec rake db_sync:dump_data RAILS_ENV=production
 
 Run this to load the tables back in.
 WARNING: this overwrites the contents of this existing table.  
-   
+
+    bundle exec rake db_sync:load_data
+
+Or run this to load the tables back in the order specified in the sync_tables array.
+WARNING: this overwrites the contents of this existing table.  
+
     bundle exec rake db_sync:load_data
 
 ## Contributing

--- a/lib/db_sync.rb
+++ b/lib/db_sync.rb
@@ -57,7 +57,6 @@ module DbSync
 
       # This assumes the first attribute (typically id) is unique and is the only unique restraint
       sql = "INSERT INTO #{table_name} (#{columns.join(',')}) values (#{values.join(',')}) ON DUPLICATE KEY UPDATE #{columns.first}=#{values.first}"
-      puts "Columns: #{columns}, Values: #{values}, SQL: #{sql}"
       ActiveRecord::Base.connection.execute(sql)
     end
   end

--- a/lib/db_sync.rb
+++ b/lib/db_sync.rb
@@ -1,13 +1,12 @@
 require "db_sync/version"
 require 'db_sync/railtie' if defined?(Rails)
-# YAML::ENGINE.yamler = "psych"
 module DbSync
-
   class Configuration
-    attr_accessor :sync_tables
+    attr_accessor :sync_tables, :db_data_folder
 
-    def initializers
-      sync_tables = []
+    def initialize
+      @sync_tables = []
+      @db_data_folder = File.join(Rails.root, 'db', 'data')
     end
   end
 
@@ -22,10 +21,10 @@ module DbSync
 
   def self.dump_data
     DbSync.configuration.sync_tables.each do |table_name|
-      location = FileUtils.mkdir_p File.join(Rails.root, 'db', 'data')
+      location = FileUtils.mkdir_p DbSync.configuration.db_data_folder
       i = "000"
       sql  = "SELECT * FROM %s"
-      File.open("#{location.first}/#{table_name}.yml", 'w') do |file|
+      File.open( File.join(location.first, "#{table_name}.yml"), 'w') do |file|
         data = ActiveRecord::Base.connection.select_all(sql % table_name)
         file.write data.inject({}) { |hash, record|
           hash["#{table_name}_#{i.succ!}"] = record
@@ -36,22 +35,29 @@ module DbSync
     end
   end
 
+  # Useful for when importing tables with foreign key references that are enforced at the DB level
+  def self.load_data_order
+    DbSync.configuration.sync_tables.each do |table_name|
+      file = File.join(DbSync.configuration.db_data_folder, "#{table_name}.yml")
+      load_document( file )
+    end
+  end
+
   def self.load_data
-    Dir["#{Rails.root}/db/data/*{yml}"].each do |data_file|
-      load_document(data_file)
+    Dir[File.join(DbSync.configuration.db_data_folder, '*yml')].each do |file|
+      load_document( file )
     end
   end
 
   def self.load_document(filename)
-    YAML.load_stream(File.new(Rails.root.join(filename), "r").read).each do |row|
-      columns =  row.values.first.map { |v| v[0]}
-      values = row.values.first.map { |v| ActiveRecord::Base.connection.quote(v[1])}
-      table_name = File.basename(filename).split(".").first
+    table_name = File.basename(filename).split(".").first
+    Psych.load_file(filename).each do |row|
+      columns = row.last.map { |k,v| k }
+      values = row.last.map { |k,v| ActiveRecord::Base.connection.quote(v) }
 
-      # This assumes the first attribute (typically id) is unique and only the unique restraint
+      # This assumes the first attribute (typically id) is unique and is the only unique restraint
       sql = "INSERT INTO #{table_name} (#{columns.join(',')}) values (#{values.join(',')}) ON DUPLICATE KEY UPDATE #{columns.first}=#{values.first}"
-      puts "SQL #{sql}"
-
+      puts "Columns: #{columns}, Values: #{values}, SQL: #{sql}"
       ActiveRecord::Base.connection.execute(sql)
     end
   end

--- a/lib/tasks/db_sync_tasks.rake
+++ b/lib/tasks/db_sync_tasks.rake
@@ -10,5 +10,10 @@ namespace :db_sync do
     DbSync.load_data
     puts "Loaded data"
   end
-end
 
+  desc "Load data from db/data in the order specified in the config.sync_tables, overwriting the existing tables"
+  task :load_data_order => :environment do
+    DbSync.load_data_order
+    puts "Loaded data"
+  end
+end


### PR DESCRIPTION
Tested with Ruby 2.5.1p57

Allow user to load_data_order the same order as it was exported so in the case where Foreign key dependencies are enforced this will allow import to succeed. 

Fixed the load_document using Psych yaml load_file method. 
